### PR TITLE
keep endpoints active so their OS/roles are reported, and disable IPv6 on test switch so only pcap traffic is seen by poseidon, prefetch workers to avoid timeout

### DIFF
--- a/helpers/faucet/docker-compose.yaml
+++ b/helpers/faucet/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
             - faucetconfrpc
     faucetconfrpc:
         restart: always
-        image: 'iqtlabs/faucetconfrpc:v0.22.4'
+        image: 'iqtlabs/faucetconfrpc:v0.22.5'
         environment:
             PYTHONUNBUFFERED: '1'
         volumes:


### PR DESCRIPTION
…eus.